### PR TITLE
Enable Open Graph/Schema.org metadata, add default og_image, and clarify site verification comments

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -68,9 +68,9 @@ max_width: 1000px
 # -----------------------------------------------------------------------------
 # Display links to the page with a preview object on social media.
 # see https://schema.org/docs/faq.html for more information
-serve_og_meta: false # Include Open Graph meta tags in the HTML head
-serve_schema_org: false # Include Schema.org in the HTML head
-og_image: # The site-wide (default for all links) Open Graph preview image
+serve_og_meta: true # Include Open Graph meta tags in the HTML head
+serve_schema_org: true # Include Schema.org in the HTML head
+og_image: /assets/img/3.jpg # The site-wide (default for all links) Open Graph preview image
 
 # Markus: see socials.yml
 
@@ -88,9 +88,12 @@ cronitor_analytics: # cronitor RUM analytics site ID (format: XXXXXXXXX)
 pirsch_analytics: # your Pirsch analytics site ID (length 32 characters)
 openpanel_analytics: # your Openpanel analytics client ID (format: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX)
 
-# For Google Search Console, see https://support.google.com/webmasters/answer/9008080?hl=en#meta_tag_verification&zippy=%2Chtml-tag
-google_site_verification: # your google-site-verification ID (Google Search Console)
-bing_site_verification: # out your bing-site-verification ID (Bing Webmaster)
+# For Google Search Console, add only the token from:
+# <meta name="google-site-verification" content="YOUR_TOKEN" />
+# Example: if content is "abc123xyz", set google_site_verification: abc123xyz
+# Docs: https://support.google.com/webmasters/answer/9008080?hl=en#meta_tag_verification&zippy=%2Chtml-tag
+google_site_verification: # your google-site-verification token (Google Search Console)
+bing_site_verification: # your bing-site-verification token (Bing Webmaster)
 
 # -----------------------------------------------------------------------------
 # Blog


### PR DESCRIPTION
### Motivation
- Enable social preview cards and structured data site-wide by serving Open Graph and Schema.org metadata. 
- Provide a default Open Graph image and clarify how to supply search console verification tokens in the config.

### Description
- Set `serve_og_meta: true` and `serve_schema_org: true` in `_config.yml` and add `og_image: /assets/img/3.jpg` as the site-wide default Open Graph image. 
- Updated the `google_site_verification` and `bing_site_verification` comment blocks with an example and a documentation link, and performed small formatting/cleanup in the config file.

### Testing
- No automated tests were run for this configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecaad1aa18832e814c8d34468d7fa6)